### PR TITLE
Clock polling fixes

### DIFF
--- a/include/config.hpp
+++ b/include/config.hpp
@@ -49,7 +49,7 @@ const int VolumeFrq = 1;
 const int MediaFrq = 2;
 const int BatteryFrq = 10;
 
-const int SleepTime = 200; // How long while loop waits before re-execution in ms
+const int SleepTime = 50; // How long while loop waits before re-execution in ms
 
 // Volume levels as a percentage for corresponding icons
 // Stored value is the bottom value for that icon

--- a/src/dwmbar-k.cpp
+++ b/src/dwmbar-k.cpp
@@ -113,8 +113,8 @@ void Clock::Init() {
     std::cout << "Clock=" << PollClock(CDir);
 #endif
     if(PollClock(CDir) == -1) {
-        Touch(CDir + "/0");
-    } else if(PollClock(CDir) != 0)
+        Touch(CDir + "/1");
+    } else if(PollClock(CDir) != 1)
         Reset();
 #ifdef COUT
     std::cout << "...Clock=" << PollClock(CDir) << std::endl;
@@ -140,7 +140,7 @@ void Clock::Pulse() {
 
 void Clock::Reset() {
         for (const auto & entry : fs::directory_iterator(CDir))
-	        rename(entry.path(), CDir + "/0");
+	        rename(entry.path(), CDir + "/1");
 }
 
 void RunModule(std::string Module) {

--- a/src/dwmbar-k.cpp
+++ b/src/dwmbar-k.cpp
@@ -14,7 +14,7 @@ class InternalClock {
 		void Pulse();
 	private:
 		void Reset();
-		int C = 0;
+		int C = 1;
 };
 
 class Clock {
@@ -24,7 +24,7 @@ class Clock {
         void Pulse();
     private:
         void Reset();
-        int C = 0;
+        int C = 1;
 };
 
 void InitDirs();
@@ -105,7 +105,7 @@ void InternalClock::Pulse() {
 }
 
 void InternalClock::Reset() {
-    C = 0;
+    C = 1;
 }
 
 void Clock::Init() {


### PR DESCRIPTION
Should resolve #3 as using `pclk` script to determine min clock speed for branch to be `59ms` - therefore a wait of 50ms should be plenty of time to protect CPU usage while maintain quick enough pulse reading.

1 based indexing for clock now prevents `$Clock % 10` from reading twice on `100` and `0` subsequently. This became an issue in animated modules such as battery during charging. Now fixed!